### PR TITLE
feat!: support `scalar` option for define custom scalar type mappings instead of legacy options

### DIFF
--- a/.changeset/proud-ravens-wait.md
+++ b/.changeset/proud-ravens-wait.md
@@ -1,0 +1,10 @@
+---
+"@proto-graphql/protoc-plugin-helpers": minor
+"@proto-graphql/codegen-core": minor
+"protoc-gen-pothos": minor
+"protoc-gen-nexus": minor
+---
+
+support scalar option for define custom scalar type mappings instead of legacy option
+
+BREAKING CHANGE: drop `long_number` and `custom_type` options

--- a/.changeset/proud-ravens-wait.md
+++ b/.changeset/proud-ravens-wait.md
@@ -8,3 +8,34 @@
 support scalar option for define custom scalar type mappings instead of legacy option
 
 BREAKING CHANGE: drop `long_number` and `custom_type` options
+
+#### Migration
+
+`long_number` and `custom_type` can be replaced with `scalar`.
+
+```patch
+ plugins:
+   name: pothos
+   out: src/__generated__/schema
+   opt:
+-    - long_number=Int
++    - scalar=int64=Int
++    - scalar=uint64=Int
++    - scalar=sint64=Int
++    - scalar=fixed64=Int
++    - scalar=sfixed64=Int
++    - scalar=google.protobuf.Int64Value=Int
++    - scalar=google.protobuf.UInt64Value=Int
++    - scalar=google.protobuf.SInt64Value=Int
++    - scalar=google.protobuf.Fixed64Value=Int
++    - scalar=google.protobuf.SFixed64Value=Int
+```
+
+```patch
+ plugins:
+   name: pothos
+   out: src/__generated__/schema
+   opt:
+-    - custom_type=google.type.Date=Date
++    - scalar=google.type.Date=Date
+```

--- a/e2e/tests/pothos--primitives--ts-proto-with-forcelong-number/buf.gen.json
+++ b/e2e/tests/pothos--primitives--ts-proto-with-forcelong-number/buf.gen.json
@@ -8,7 +8,16 @@
       "opt": [
         "import_prefix=@proto-graphql/e2e-testapis-ts-proto-with-forcelong-number/lib/",
         "pothos_builder_path=../../builder",
-        "long_number=Int"
+        "scalar=int64=Int",
+        "scalar=uint64=Int",
+        "scalar=sint64=Int",
+        "scalar=fixed64=Int",
+        "scalar=sfixed64=Int",
+        "scalar=google.protobuf.Int64Value=Int",
+        "scalar=google.protobuf.UInt64Value=Int",
+        "scalar=google.protobuf.SInt64Value=Int",
+        "scalar=google.protobuf.Fixed64Value=Int",
+        "scalar=google.protobuf.SFixed64Value=Int"
       ]
     }
   ]

--- a/e2e/tests/pothos--wktypes--ts-proto-with-forcelong-number/buf.gen.json
+++ b/e2e/tests/pothos--wktypes--ts-proto-with-forcelong-number/buf.gen.json
@@ -8,7 +8,16 @@
       "opt": [
         "import_prefix=@proto-graphql/e2e-testapis-ts-proto-with-forcelong-number/lib/",
         "pothos_builder_path=../../builder",
-        "long_number=Int"
+        "scalar=int64=Int",
+        "scalar=uint64=Int",
+        "scalar=sint64=Int",
+        "scalar=fixed64=Int",
+        "scalar=sfixed64=Int",
+        "scalar=google.protobuf.Int64Value=Int",
+        "scalar=google.protobuf.UInt64Value=Int",
+        "scalar=google.protobuf.SInt64Value=Int",
+        "scalar=google.protobuf.Fixed64Value=Int",
+        "scalar=google.protobuf.SFixed64Value=Int"
       ]
     }
   ]

--- a/packages/@proto-graphql/codegen-core/src/types/options.ts
+++ b/packages/@proto-graphql/codegen-core/src/types/options.ts
@@ -1,20 +1,110 @@
+import { ProtoScalarType } from "@proto-graphql/proto-descriptors";
+
 export interface TypeOptions {
   partialInputs: boolean;
-  typeMappings: Record<string, string>;
   /**
-   * Which type to map Protobuf's 64-bit integer type to on GraphQL(default: "String").
-   * Only Int, String or custom scalars is supported.
+   * @defaultValue
+   * * Protobuf's 64-bit integer types to `String`
+   * * Protobuf's bytes type to `Bytes`
+   * * `google.protobuf.Timestamp` to `DateTime`
    *
-   * @remarks
-   * Support only protoc-gen-pothos.
-   *
-   * @remarks
-   * If you use ts-proto:
-   * - when `longNumber="String"`, you should specify `forceLong=string` for ts-proto
-   * - when `longNumber="Int"`, you should specify `forceLong=number` for ts-proto
+   * ```
+   * {
+   *   int32: "Int",
+   *   int64: "String",
+   *   uint32: "Int",
+   *   uint64: "String",
+   *   sint32: "Int",
+   *   sint64: "String",
+   *   fixed32: "Int",
+   *   fixed64: "String",
+   *   sfixed32: "Int",
+   *   sfixed64: "String",
+   *   float: "Float",
+   *   double: "Float",
+   *   string: "String",
+   *   bool: "Boolean",
+   *   bytes: "Bytes",
+   *   "google.protobuf.Int32Value": "Int",
+   *   "google.protobuf.Int64Value": "String",
+   *   "google.protobuf.UInt32Value": "Int",
+   *   "google.protobuf.UInt64Value": "String",
+   *   "google.protobuf.SInt32Value": "Int",
+   *   "google.protobuf.SInt64Value": "String",
+   *   "google.protobuf.Fixed32Value": "Int",
+   *   "google.protobuf.Fixed64Value": "String",
+   *   "google.protobuf.SFixed32Value": "Int",
+   *   "google.protobuf.SFixed64Value": "String",
+   *   "google.protobuf.FloatValue": "Float",
+   *   "google.protobuf.DoubleValue": "Float",
+   *   "google.protobuf.StringValue": "String",
+   *   "google.protobuf.BoolValue": "Boolean",
+   *   "google.protobuf.BytesValue": "Bytes",
+   *   "google.protobuf.Timestamp": "DateTime",
+   * }
+   * ```
+   * @example Map long numbers to `BigInt` (default: `String`)
+   * ```
+   * {
+   *   "int64": "BigInt",
+   *   "uint64": "BigInt",
+   *   "sint64": "BigInt",
+   *   "fixed64": "BigInt",
+   *   "sfixed64": "BigInt",
+   *   "google.protobuf.Int64": "BigInt",
+   *   "google.protobuf.UInt64": "BigInt",
+   *   "google.protobuf.SInt64": "BigInt",
+   *   "google.protobuf.Fixed64": "BigInt",
+   *   "google.protobuf.SFixed64": "BigInt",
+   * }
+   * ```
+   * @example Map `google.protobuf.Timestamp` to `DateTime`, `google.type.Date` to `Date`
+   * ```
+   * {
+   *   "google.protobuf.Timestamp": "DateTime",
+   *   "google.type.Date": "Date",
+   * }
+   * ```
    */
-  longNumber: LongNumberMapping;
+  scalarMapping: Record<string, string>;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type LongNumberMapping = "String" | "Int" | (string & {});
+export const defaultScalarMapping: Readonly<
+  Record<
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    ProtoScalarType | (string & {}),
+    string
+  >
+> = {
+  int32: "Int",
+  int64: "String",
+  uint32: "Int",
+  uint64: "String",
+  sint32: "Int",
+  sint64: "String",
+  fixed32: "Int",
+  fixed64: "String",
+  sfixed32: "Int",
+  sfixed64: "String",
+  float: "Float",
+  double: "Float",
+  string: "String",
+  bool: "Boolean",
+  bytes: "Bytes",
+  "google.protobuf.Int32Value": "Int",
+  "google.protobuf.Int64Value": "String",
+  "google.protobuf.UInt32Value": "Int",
+  "google.protobuf.UInt64Value": "String",
+  "google.protobuf.SInt32Value": "Int",
+  "google.protobuf.SInt64Value": "String",
+  "google.protobuf.Fixed32Value": "Int",
+  "google.protobuf.Fixed64Value": "String",
+  "google.protobuf.SFixed32Value": "Int",
+  "google.protobuf.SFixed64Value": "String",
+  "google.protobuf.FloatValue": "Float",
+  "google.protobuf.DoubleValue": "Float",
+  "google.protobuf.StringValue": "String",
+  "google.protobuf.BoolValue": "Boolean",
+  "google.protobuf.BytesValue": "Bytes",
+  "google.protobuf.Timestamp": "DateTime",
+};

--- a/packages/@proto-graphql/codegen-core/src/types/types.ts
+++ b/packages/@proto-graphql/codegen-core/src/types/types.ts
@@ -22,7 +22,6 @@ import {
   isIgnoredInputType,
   isIgnoredType,
   isInterface,
-  isScalar,
   isSquashedUnion,
 } from "./util";
 
@@ -162,12 +161,8 @@ function detectType<
     case "Message": {
       assert(proto.type && proto.type.kind === "Message");
       const msg = proto.type;
-      if (isScalar(msg, options)) {
-        return new ScalarType(
-          proto,
-          options.typeMappings[msg.fullName.toString()] as any
-        );
-      }
+      const customScalar = options.scalarMapping[msg.fullName.toString()];
+      if (customScalar) return new ScalarType(proto, customScalar);
       return f(msg, options);
     }
     case "Enum": {
@@ -175,42 +170,7 @@ function detectType<
       return new EnumType(proto.type, options);
     }
     case "Scalar": {
-      switch (proto.type.type) {
-        case "string":
-          return new ScalarType(proto, "String");
-        case "double":
-        case "float":
-          return new ScalarType(proto, "Float");
-        case "int64":
-          return new ScalarType(proto, options.longNumber);
-        case "uint64":
-          return new ScalarType(proto, options.longNumber);
-        case "int32":
-          return new ScalarType(proto, "Int");
-        case "fixed64":
-          return new ScalarType(proto, options.longNumber);
-        case "fixed32":
-          return new ScalarType(proto, "Int");
-        case "uint32":
-          return new ScalarType(proto, "Int");
-        case "sfixed32":
-          return new ScalarType(proto, "Int");
-        case "sfixed64":
-          return new ScalarType(proto, options.longNumber);
-        case "sint32":
-          return new ScalarType(proto, "Int");
-        case "sint64":
-          return new ScalarType(proto, options.longNumber);
-        case "bool":
-          return new ScalarType(proto, "Boolean");
-        case "bytes":
-          throw "not supported";
-        /* istanbul ignore next */
-        default: {
-          const _exhaustiveCheck: never = proto.type.type;
-          throw "unreachable";
-        }
-      }
+      return new ScalarType(proto, options.scalarMapping[proto.type.type]);
     }
     /* istanbul ignore next */
     default: {

--- a/packages/@proto-graphql/codegen-core/src/types/util.ts
+++ b/packages/@proto-graphql/codegen-core/src/types/util.ts
@@ -12,7 +12,6 @@ import { pascalCase } from "change-case";
 import { ExtensionFieldInfo } from "google-protobuf";
 import { FieldDescriptorProto } from "google-protobuf/google/protobuf/descriptor_pb";
 
-import { TypeOptions } from "./options";
 import * as extensions from "../__generated__/extensions/graphql/schema_pb";
 
 export function gqlTypeName(
@@ -149,10 +148,6 @@ export function isInterface(m: ProtoMessage): boolean {
 
 export function isSquashedUnion(m: ProtoMessage): boolean {
   return getExtension(m, "objectType")?.getSquashUnion() ?? false;
-}
-
-export function isScalar(m: ProtoMessage, opts: TypeOptions): boolean {
-  return m.fullName.toString() in opts.typeMappings;
 }
 
 export function isRequiredField(

--- a/packages/@proto-graphql/protoc-plugin-helpers/src/parseParams.ts
+++ b/packages/@proto-graphql/protoc-plugin-helpers/src/parseParams.ts
@@ -90,30 +90,10 @@ export function parseParams<DSL extends PrinterOptions["dsl"]>(
         ).pothos.builderPath = toString(k, v);
         break;
       }
-<<<<<<< HEAD
-||||||| 06bb308
-      case "long_number": {
-        params.type.longNumber = toString(k, v);
-        params.type.typeMappings = {
-          ...params.type.typeMappings,
-          ...wktypeMappings({ longNumber: params.type.longNumber }),
-        };
-        break;
-      }
-=======
-      case "long_number": {
-        params.type.longNumber = toString(k, v);
-        params.type.typeMappings = {
-          ...params.type.typeMappings,
-          ...wktypeMappings({ longNumber: params.type.longNumber }),
-        };
-        break;
-      }
       case "ignore_non_message_oneof_fields": {
         params.type.ignoreNonMessageOneofFields = true;
         break;
       }
->>>>>>> main
       default:
         throw new Error(`unknown param: ${kv}`);
     }

--- a/packages/@proto-graphql/protoc-plugin-helpers/src/parseParams.ts
+++ b/packages/@proto-graphql/protoc-plugin-helpers/src/parseParams.ts
@@ -1,6 +1,6 @@
 import {
+  defaultScalarMapping,
   fileLayouts,
-  LongNumberMapping,
   PrinterOptions,
   TypeOptions,
 } from "@proto-graphql/codegen-core";
@@ -15,8 +15,7 @@ export function parseParams<DSL extends PrinterOptions["dsl"]>(
   const params = {
     type: {
       partialInputs: false,
-      typeMappings: wktypeMappings({ longNumber: "String" }),
-      longNumber: "String",
+      scalarMapping: { ...defaultScalarMapping },
     } as TypeOptions,
     printer: {
       dsl,
@@ -77,11 +76,11 @@ export function parseParams<DSL extends PrinterOptions["dsl"]>(
         params.printer.fileLayout = s;
         break;
       }
-      case "custom_type": {
+      case "scalar": {
         const idx = v.indexOf("=");
         const [protoType, gqlType] =
           idx === -1 ? [v, ""] : [v.slice(0, idx), v.slice(idx + 1)];
-        params.type.typeMappings[protoType] = gqlType;
+        params.type.scalarMapping[protoType] = gqlType;
         break;
       }
       case "pothos_builder_path": {
@@ -90,32 +89,10 @@ export function parseParams<DSL extends PrinterOptions["dsl"]>(
         ).pothos.builderPath = toString(k, v);
         break;
       }
-      case "long_number": {
-        params.type.longNumber = toString(k, v);
-        params.type.typeMappings = {
-          ...params.type.typeMappings,
-          ...wktypeMappings({ longNumber: params.type.longNumber }),
-        };
-        break;
-      }
       default:
         throw new Error(`unknown param: ${kv}`);
     }
   }
 
   return params;
-}
-
-function wktypeMappings({ longNumber }: { longNumber: LongNumberMapping }) {
-  return {
-    "google.protobuf.Int32Value": "Int",
-    "google.protobuf.Int64Value": longNumber,
-    "google.protobuf.UInt32Value": "Int",
-    "google.protobuf.UInt64Value": longNumber,
-    "google.protobuf.FloatValue": "Float",
-    "google.protobuf.DoubleValue": "Float",
-    "google.protobuf.BoolValue": "Boolean",
-    "google.protobuf.StringValue": "String",
-    "google.protobuf.Timestamp": "DateTime",
-  };
 }

--- a/packages/protoc-gen-nexus/src/__tests__/customTypes.test.ts
+++ b/packages/protoc-gen-nexus/src/__tests__/customTypes.test.ts
@@ -7,7 +7,7 @@ describe("custom types", () => {
   it("generates nexus DSLs", async () => {
     const resp = await processCodeGeneration(
       "testapis.custom_types",
-      "custom_type=testapis.custom_types.Date=Date"
+      "scalar=testapis.custom_types.Date=Date"
     );
     snapshotGeneratedFiles(resp, [
       "custom_types/post_pb_nexus.ts",

--- a/packages/protoc-gen-pothos/README.md
+++ b/packages/protoc-gen-pothos/README.md
@@ -46,8 +46,34 @@ plugins:
   - path to file that exports pothos builder
 - `emit_imported_files` (`bool`, optional)
   - if `true`, protoc-gen-pothos also emits types defined in imported `.proto` file.
-- `custom_type` (`string`, optional)
-- `long_number` (`string`, optional, default `String`)
+- `scalar` (`string`, optional)
+
+  - add scalar mapping
+  - default:
+    - Protobuf's 64-bit integer types to `String`
+    - Protobuf's bytes type to `Bytes`
+    - `google.protobuf.Timestamp` to `DateTime`
+  - e.g.
+    - Map `google.type.Date` to `Date`
+      - ```yaml
+        opt:
+          - scalar=google.type.Date=Date
+        ```
+        opt:
+    - Map Protobuf's 64-bit integer types to `BigInt`
+      - ```yaml
+        opt:
+          - scalar=int64=BigInt
+          - scalar=uint64=BigInt
+          - scalar=sint64=BigInt
+          - scalar=fixed64=BigInt
+          - scalar=sfixed64=BigInt
+          - scalar=google.protobuf.Int64Value=BigInt
+          - scalar=google.protobuf.UInt64Value=BigInt
+          - scalar=google.protobuf.SInt64Value=BigInt
+          - scalar=google.protobuf.Fixed64Value=BigInt
+          - scalar=google.protobuf.SFixed64Value=BigInt
+        ```
 
 ## Author
 

--- a/packages/protoc-gen-pothos/src/__tests__/__helpers__/process.test.helper.ts
+++ b/packages/protoc-gen-pothos/src/__tests__/__helpers__/process.test.helper.ts
@@ -1,4 +1,3 @@
-import { LongNumberMapping } from "@proto-graphql/codegen-core";
 import {
   buildCodeGeneratorRequest,
   TestapisPackage,
@@ -21,7 +20,7 @@ export function generateDSLs(
     withPrefix?: boolean;
     perGraphQLType?: boolean;
     partialInputs?: boolean;
-    longNumber?: LongNumberMapping;
+    scalars?: Record<string, string>;
   } = {}
 ) {
   const params = [];
@@ -42,8 +41,10 @@ export function generateDSLs(
   if (opts.partialInputs) {
     params.push("partial_inputs");
   }
-  if (opts.longNumber) {
-    params.push(`long_number=${opts.longNumber}`);
+  if (opts.scalars) {
+    for (const [k, v] of Object.entries(opts.scalars)) {
+      params.push(`scalar=${k}=${v}`);
+    }
   }
   return processCodeGeneration(pkg, params.join(","));
 }

--- a/packages/protoc-gen-pothos/src/__tests__/customTypes.test.ts
+++ b/packages/protoc-gen-pothos/src/__tests__/customTypes.test.ts
@@ -7,7 +7,7 @@ describe("custom types", () => {
   it("generates pothos DSLs", async () => {
     const resp = await processCodeGeneration(
       "testapis.custom_types",
-      "custom_type=testapis.custom_types.Date=Date"
+      "scalar=testapis.custom_types.Date=Date"
     );
     snapshotGeneratedFiles(resp, [
       "custom_types/post.pb.pothos.ts",

--- a/scripts/setupE2ETests.ts
+++ b/scripts/setupE2ETests.ts
@@ -126,7 +126,16 @@ async function genBufGemTemplate(test: TestCase): Promise<void> {
       "ts-proto-with-forcelong-number": [
         "import_prefix=@proto-graphql/e2e-testapis-ts-proto-with-forcelong-number/lib/",
         "pothos_builder_path=../../builder",
-        "long_number=Int",
+        "scalar=int64=Int",
+        "scalar=uint64=Int",
+        "scalar=sint64=Int",
+        "scalar=fixed64=Int",
+        "scalar=sfixed64=Int",
+        "scalar=google.protobuf.Int64Value=Int",
+        "scalar=google.protobuf.UInt64Value=Int",
+        "scalar=google.protobuf.SInt64Value=Int",
+        "scalar=google.protobuf.Fixed64Value=Int",
+        "scalar=google.protobuf.SFixed64Value=Int",
       ],
     },
   };


### PR DESCRIPTION

- add `scalar` option
-  BREAKING CHANGE: drop `long_number` and `custom_type` options