### PR TITLE
fix: proto-gen-nexus google type

### DIFF
--- a/packages/@proto-graphql/codegen-core/src/printer/util.ts
+++ b/packages/@proto-graphql/codegen-core/src/printer/util.ts
@@ -247,6 +247,14 @@ export function isProtobufWrapperType(
   );
 }
 
+export function isGoogleWellKnownType(
+  proto: ProtoField["type"]
+): proto is ProtoMessage {
+  return (
+    proto.kind === "Message" && proto.file.name.startsWith("google/type/")
+  );
+}
+
 export function isProtobufWellKnownType(
   proto: ProtoField["type"]
 ): proto is ProtoMessage {

--- a/packages/protoc-gen-nexus/src/dslgen/printers/field.ts
+++ b/packages/protoc-gen-nexus/src/dslgen/printers/field.ts
@@ -6,6 +6,7 @@ import {
   InputObjectType,
   InterfaceType,
   isProtobufLong,
+  isGoogleWellKnownType,
   isProtobufWellKnownType,
   ObjectField,
   ObjectOneofField,
@@ -251,7 +252,7 @@ function createResolverCode(
     }
   }
 
-  if (isProtobufWellKnownType(field.proto.type)) {
+  if (isProtobufWellKnownType(field.proto.type)|| isGoogleWellKnownType(field.proto.type)) {
     const transformer = code`${impProtoNexus(
       "getTransformer"
     )}("${field.proto.type.fullName.toString()}")`;

--- a/packages/protoc-gen-nexus/src/dslgen/printers/inputObjectType.ts
+++ b/packages/protoc-gen-nexus/src/dslgen/printers/inputObjectType.ts
@@ -4,6 +4,7 @@ import {
   InputObjectField,
   InputObjectType,
   isProtobufLong,
+  isGoogleWellKnownType,
   isProtobufWellKnownType,
   protobufGraphQLExtensions,
   protoType,
@@ -93,7 +94,7 @@ export function createToProtoFuncCode(
         type.fields.map((f) => {
           let wrapperFunc: (v: Code) => Code = (v) => v;
           if (f.type instanceof ScalarType) {
-            if (isProtobufWellKnownType(f.proto.type)) {
+            if (isProtobufWellKnownType(f.proto.type) || isGoogleWellKnownType(f.proto.type)) {
               const protoFullName = f.proto.type.fullName.toString();
               const transformer = code`${impProtoNexus(
                 "getTransformer"


### PR DESCRIPTION
We got an error when we tried to generate the `nexus` field for `google.Type.Date` by using the `proto-gen-nexus` (**version: 0.6.2**).

## Expected Behavior
```typescript
  t.field("birthday", {
    type: nullable("Date"),
    resolve: (source) => {
      const value = source.getBirthday();
      if (value == null) {
        return null;
      }
      // THE EXPECTED
      return getTransformer("google.type.Date").protoToGql(value);
    },
    extensions: {
      protobufField: { name: "birthday", typeFullName: "google.type.Date" },
    },
```

## Current Behavior
```typescript
  t.field("birthday", {
      type: nullable("Date"),
      resolve: (source) => {
        const value = source.getBirthday();
        if (value == null) {
          return null;
        }
        // ACTUALITY
        return value;
      },
      extensions: {
        protobufField: { name: "birthday", typeFullName: "google.type.Date" },
      }
```

## Root cause
The error was found when handling WellKnownType. Currently, it only handles `google.protobuf` type (by isProtobufWellKnownType), but does not handle `google.Type` (`google.Type.Date`)

## Related issue 
https://github.com/proto-graphql/proto-graphql-js/issues/315